### PR TITLE
Fix Uncaught Error: Class errors in BLT issue 3858.

### DIFF
--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -82,6 +82,10 @@ if (getenv('AH_SITE_ENVIRONMENT') &&
             'factory' => ['@memcache.factory', 'get'],
             'arguments' => ['container'],
           ],
+          'lock.container' => [
+            'class' => 'Drupal\memcache\Lock\MemcacheLockBackend',
+            'arguments' => ['container', '@memcache.backend.cache.container'],
+          ],
           'cache_tags_provider.container' => [
             'class' => 'Drupal\Core\Cache\DatabaseCacheTagsChecksum',
             'arguments' => ['@database'],
@@ -93,7 +97,6 @@ if (getenv('AH_SITE_ENVIRONMENT') &&
               '@memcache.backend.cache.container',
               '@cache_tags_provider.container',
               '@memcache.timestamp.invalidator.bin',
-              '@memcache.settings',
             ],
           ],
         ],


### PR DESCRIPTION
These changes resolves the errors mentioned in https://github.com/acquia/blt/issues/3858, as the current settings only work with the alpha7 version of the memcache module. See https://www.drupal.org/project/memcache/issues/3002858