### PR TITLE
Adjust memcache module path for multisite structure.

### DIFF
--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -26,6 +26,14 @@ if (getenv('AH_SITE_ENVIRONMENT') &&
   $memcached_exists = class_exists('Memcached', FALSE);
   $memcache_services_yml = DRUPAL_ROOT . '/modules/contrib/memcache/memcache.services.yml';
   $memcache_module_is_present = file_exists($memcache_services_yml);
+  $module_path = DRUPAL_ROOT . '/modules/contrib/memcache';
+
+  // On Acquia environment we have contrib modules inside sites directory.
+  if (!$memcache_module_is_present && !empty($site_dir)) {
+    $memcache_services_yml = DRUPAL_ROOT . '/sites/' . $site_dir . '/modules/contrib/memcache/memcache.services.yml';
+    $memcache_module_is_present = file_exists($memcache_services_yml);
+    $module_path = DRUPAL_ROOT . '/sites/' . $site_dir . '/modules/contrib/memcache';
+  }
   if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
     // Use Memcached extension if available.
     if ($memcached_exists) {
@@ -33,7 +41,7 @@ if (getenv('AH_SITE_ENVIRONMENT') &&
     }
     if (class_exists(ClassLoader::class)) {
       $class_loader = new ClassLoader();
-      $class_loader->addPsr4('Drupal\\memcache\\', DRUPAL_ROOT . '/modules/contrib/memcache/src');
+      $class_loader->addPsr4('Drupal\\memcache\\', $module_path . '/src');
       $class_loader->register();
       $settings['container_yamls'][] = $memcache_services_yml;
 

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -6,6 +6,7 @@
  */
 
 use Composer\Autoload\ClassLoader;
+use Acquia\Blt\Robo\Common\EnvironmentDetector;
 
 /**
  * Use memcache as cache backend.
@@ -30,9 +31,11 @@ if (getenv('AH_SITE_ENVIRONMENT') &&
 
   // On Acquia environment we have contrib modules inside sites directory.
   if (!$memcache_module_is_present && !empty($site_dir)) {
-    $memcache_services_yml = DRUPAL_ROOT . '/sites/' . $site_dir . '/modules/contrib/memcache/memcache.services.yml';
+    // $site_path is always set and exposed by the Drupal Kernel.
+    $site_name = EnvironmentDetector::getSiteName($site_path);
+    $memcache_services_yml = DRUPAL_ROOT . '/sites/' . $site_name . '/modules/contrib/memcache/memcache.services.yml';
     $memcache_module_is_present = file_exists($memcache_services_yml);
-    $module_path = DRUPAL_ROOT . '/sites/' . $site_dir . '/modules/contrib/memcache';
+    $module_path = DRUPAL_ROOT . '/sites/' . $site_name . '/modules/contrib/memcache';
   }
   if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
     // Use Memcached extension if available.

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -5,8 +5,8 @@
  * Contains caching configuration.
  */
 
-use Composer\Autoload\ClassLoader;
 use Acquia\Blt\Robo\Common\EnvironmentDetector;
+use Composer\Autoload\ClassLoader;
 
 /**
  * Use memcache as cache backend.

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -30,12 +30,14 @@ if (getenv('AH_SITE_ENVIRONMENT') &&
   $module_path = DRUPAL_ROOT . '/modules/contrib/memcache';
 
   // On Acquia environment we have contrib modules inside sites directory.
-  if (!$memcache_module_is_present && !empty($site_dir)) {
+  if (!$memcache_module_is_present) {
     // $site_path is always set and exposed by the Drupal Kernel.
     $site_name = EnvironmentDetector::getSiteName($site_path);
-    $memcache_services_yml = DRUPAL_ROOT . '/sites/' . $site_name . '/modules/contrib/memcache/memcache.services.yml';
-    $memcache_module_is_present = file_exists($memcache_services_yml);
-    $module_path = DRUPAL_ROOT . '/sites/' . $site_name . '/modules/contrib/memcache';
+    if (!empty($site_name)) {
+      $memcache_services_yml = DRUPAL_ROOT . '/sites/' . $site_name . '/modules/contrib/memcache/memcache.services.yml';
+      $memcache_module_is_present = file_exists($memcache_services_yml);
+      $module_path = DRUPAL_ROOT . '/sites/' . $site_name . '/modules/contrib/memcache';
+    }
   }
   if ($memcache_module_is_present && ($memcache_exists || $memcached_exists)) {
     // Use Memcached extension if available.


### PR DESCRIPTION
We have multisite, where contrib modules stored in sites/<site name> directory, in this case, memcache settings not applied.
Added one more path to check if the memcache module exists.