### PR TITLE
Issue #22: Should not activate under Cloud Next.

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -40,8 +40,6 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
-          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "7.4" ]
         coveralls-enable: [ "FALSE" ]
         include:

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -1,6 +1,10 @@
 ---
 name: ORCA CI
-on: [ push, pull_request ]
+on:
+  push: ~
+  pull_request: ~
+  schedule:
+    - cron: "0 0 * * *"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -36,6 +40,8 @@ jobs:
           - ISOLATED_TEST_ON_NEXT_MINOR_DEV
           - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           - LOOSE_DEPRECATED_CODE_SCAN
+          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "7.4" ]
         coveralls-enable: [ "FALSE" ]
         include:
@@ -43,8 +49,14 @@ jobs:
             php-version: "8.0"
             coveralls-enable: "FALSE"
           - orca-job: ISOLATED_TEST_ON_CURRENT
-            php-version: "7.3"
-            coveralls-enable: "TRUE"
+            php-version: "8.1"
+            coveralls-enable: "FALSE"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+            orca-enable-nightwatch: "TRUE"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+            orca-enable-nightwatch: "TRUE"
 
     steps:
       - uses: actions/checkout@v2
@@ -82,3 +94,10 @@ jobs:
       - name: After failure
         if: ${{ failure() }}
         run: ../orca/bin/ci/after_failure.sh
+
+  all-successful:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - name: All checks successful
+      run: echo "🎉"

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -48,12 +48,6 @@ jobs:
           - orca-job: ISOLATED_TEST_ON_CURRENT
             php-version: "8.1"
             coveralls-enable: "FALSE"
-          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.1"
-            orca-enable-nightwatch: "TRUE"
-          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-            php-version: "8.1"
-            orca-enable-nightwatch: "TRUE"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -12,7 +12,6 @@ jobs:
       ORCA_SUT_NAME: acquia/memcache-settings
       ORCA_SUT_BRANCH: master
       ORCA_VERSION: ^3
-      ORCA_PACKAGES_CONFIG_ALTER: ../memcache-settings/packages_alter.yml
       ORCA_JOB: ${{ matrix.orca-job }}
       ORCA_COVERALLS_ENABLE: ${{ matrix.coveralls-enable }}
       COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Acquia Memcache settings
 ====
 
-This is a Composer package providing a recommended set of Memcache settings for use with Acquia Cloud and Acquia Cloud Site Factory.
+This is a Composer package providing a recommended set of Memcache settings for use with **Acquia Cloud Classic** and **Acquia Cloud Site Factory**. This package is not required for **Acquia Cloud Next** applications, as Acquia Cloud Next manages memcache configuration automatically.
 
 These settings are continuously updated based on the [publicly available documentation](https://docs.acquia.com/acquia-cloud/performance/memcached/enable/).
 

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -3,6 +3,7 @@
 /**
  * @file
  * Contains caching configuration.
+ *
  * Last change: 07/07/2022
  */
 

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -14,12 +14,20 @@ use Composer\Autoload\ClassLoader;
  * installed. Avoids the need to patch core and allows for overriding the
  * default backend when installing Drupal.
  *
+ * Sites on Acquia Cloud Next should allow platform to enable memcache instead
+ * of using this snippet.
+ *
  * @see https://www.drupal.org/node/2766509
  */
+
+// Determine if site is currently running under Acquia Cloud Next.
+$is_acquia_cloud_next = (getenv("HOME") == "/home/clouduser");
+
 if (getenv('AH_SITE_ENVIRONMENT') &&
   array_key_exists('memcache', $settings) &&
   array_key_exists('servers', $settings['memcache']) &&
-  !empty($settings['memcache']['servers'])
+  !empty($settings['memcache']['servers']) &&
+  !$is_acquia_cloud_next
 ) {
   // Check for PHP Memcached libraries.
   $memcache_exists = class_exists('Memcache', FALSE);

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -4,7 +4,7 @@
  * @file
  * Contains caching configuration.
  *
- * Last change: 07/07/2022
+ * Last change: 07/07/2022.
  */
 
 use Composer\Autoload\ClassLoader;

--- a/memcache.settings.php
+++ b/memcache.settings.php
@@ -3,6 +3,7 @@
 /**
  * @file
  * Contains caching configuration.
+ * Last change: 07/07/2022
  */
 
 use Composer\Autoload\ClassLoader;

--- a/packages_alter.yml
+++ b/packages_alter.yml
@@ -1,6 +1,0 @@
-# ORCA package data to merge into the main specification at runtime using the
-# "ORCA_PACKAGES_CONFIG_ALTER" environment variable. See config/packages.yml for
-# more information, including the schema.
----
-acquia/memcache-settings:
-  type: library


### PR DESCRIPTION
Code is fine under Cloud Classic, however it does not under Cloud Next. Examples: acquia_hosting_site_info doesn't exist on ACN, the Memcache binary protocol and compression are both disallowed on ACN, etc. 

Since the platform already auto-includes similar (but correctly-working code), this change makes this code not do anything.